### PR TITLE
Add session passing to functions

### DIFF
--- a/bitwarden_keyring/__init__.py
+++ b/bitwarden_keyring/__init__.py
@@ -174,8 +174,9 @@ def get_session(environ):
     return ask_for_session(bool(user))
 
 
-def get_password(service, username):
-    session = get_session(os.environ)
+def get_password(service, username, session=None):
+    if session == None:
+        session = get_session(os.environ)
 
     # Making sure we're up to date
     bw("sync", session=session)
@@ -191,8 +192,9 @@ def get_password(service, username):
     return select_match(matches)
 
 
-def set_password(service, username, password):
-    session = get_session(os.environ)
+def set_password(service, username, password, session=None):
+    if session == None:
+        session = get_session(os.environ)
 
     template_str = bw("get", "template", "item", session=session)
 
@@ -226,8 +228,9 @@ def confirm_delete(session, credential):
     print("Cancelled.")
 
 
-def delete_password(service, username):
-    session = get_session(os.environ)
+def delete_password(service, username, session=None):
+    if session == None:
+        session = get_session(os.environ)
 
     bw("sync", session=session)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = bitwarden-keyring
 description = Keyring backend reading password data from Bitwarden
-version = 0.2.1
+version = 0.2.2
 author = Joachim Jablon
 author_email = ewjoachim@gmail.com
 url = https://github.com/ewjoachim/bitwarden-keyring


### PR DESCRIPTION
- Adds ability to pass session variable to `get_password`, `set_password`, and `delete_password` functions. Default = `None`. 
- Adds tests for new functionality with 100% coverage.
    - Double check these tests for validity. I don't have much exp writing tests.
- Minor version bump from 0.2.1 to 0.2.2